### PR TITLE
fix Hyprland config

### DIFF
--- a/nixos/wayland.nix
+++ b/nixos/wayland.nix
@@ -6,13 +6,6 @@
     src = builtins.fetchTarball "https://github.com/hyprwm/Hyprland/archive/master.tar.gz";
   }).defaultNix;
 
-  # Hyprland XDG-Desktop Portal
-  xdg-desktop-portal-hyprland =
-    let
-      xdph = builtins.getFlake "github:hyprwm/xdg-desktop-portal-hyprland";
-    in
-    xdph.packages.${pkgs.system}.hyprland-share-picker.override { inherit hyprland; };
-
   # Webcord
   webcord = (import flake-compat {
     src = builtins.fetchTarball "https://github.com/fufexan/webcord-flake/archive/refs/heads/master.zip";
@@ -26,6 +19,7 @@ in {
   environment.variables = {
     _JAVA_AWT_WM_NONREPARENTING = "1";
     MOZ_ENABLE_WAYLAND = "1";
+    NIXOS_OZONE_WL = "1";
     QT_QPA_PLATFORM = "wayland";
     QT_WAYLAND_DISABLE_WINDOWDECORATION = "1";
     SDL_VIDEODRIVER = "wayland";
@@ -38,24 +32,11 @@ in {
     wlr-randr
     eww-wayland
     wofi
-    xdg-desktop-portal-hyprland
-
-    # polkit
-    polkit
 
     # discord but based
     webcord.packages.${pkgs.system}.default
   ];
 
-  # XDG Portal
-  xdg.portal = {
-    enable = true;
-    wlr.enable = false;
-    extraPortals = [
-      xdg-desktop-portal-hyprland
-    ];
-  };
-  
   # Fix cursor for Nvidia
   environment.variables.WLR_NO_HARDWARE_CURSORS = "1";
 
@@ -67,11 +48,6 @@ in {
 
   programs.hyprland = {
     enable = true;
-    xwayland = {
-      enable = true;
-      hidpi = true;
-    };
-    package = hyprland.packages.${pkgs.system}.default;
     nvidiaPatches = true;
   };
 }


### PR DESCRIPTION
Some of the config options were redundant or outright contradicted default
(known-working) settings. This should fix screen sharing.